### PR TITLE
Sync port on README + token config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alertmanager configuration file:
 
 ```yaml
 webhook_configs:
-- url: http://127.0.0.1:8111/hook
+- url: http://127.0.0.1:8000/hook
   http_config:
     basic_auth:
       username: alertmanager
@@ -128,7 +128,7 @@ To replicate the configuration example above:
     enable = true;
     settings = {
       http = {
-        addr = "127.0.0.1:8111";
+        addr = "127.0.0.1:8000";
       };
       ntfy = {
         baseurl = "https://ntfy.sh";

--- a/config.example.yml
+++ b/config.example.yml
@@ -8,6 +8,8 @@ ntfy:
   auth:
     username: "admin"
     password: "verysecure"
+    # Token authentication is also available
+    # token: <token>
   notification:
     # The topic can either be a hardcoded string or a gval expression that evaluates to a string
     topic: alertmanager


### PR DESCRIPTION
The token configuration is apparently available (and working), make it clear in the doc. And sync the port used in the README since it might be confusing.