### PR TITLE
chore: add healthcheck

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,7 +70,19 @@ func New(logger *zap.Logger, cfg *config.Config) *Server {
 		http:   &http.Client{Timeout: cfg.Ntfy.Timeout},
 	}
 	s.e.POST("/hook", s.handleWebhook)
+	s.e.GET("/health", s.handleHealthCheck)
 	return &s
+}
+
+func (s *Server) handleHealthCheck(c *gin.Context) {
+	logger := s.logger
+	if requestID, ok := c.Get(keyRequestID); ok {
+		logger = logger.With(zap.String(keyRequestID, requestID.(string)))
+	}
+	logger.Debug("Handling healthcheck")
+	c.JSON(200, gin.H{
+		"status": "OK",
+	})
 }
 
 func (s *Server) handleWebhook(c *gin.Context) {


### PR DESCRIPTION
Add a simple dedicated health check endpoint to `/health`. 
There is an argument that this endpoint should not have to be authenticated, let me know your thoughts on that.