### PR TITLE
Containerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build
 on: [pull_request, push]
 jobs:
-  build:
+  nix:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,3 +14,41 @@ jobs:
       - name: Check
         run: |
           nix flake check
+  container:
+    runs-on: ubuntu-latest
+    env:
+      PLATFORMS: linux/amd64,linux/arm64
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - name: Build container image
+        if: "!startsWith(github.ref_name, 'v')"
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: false
+      - name: Log into GHCR
+        if: startsWith(github.ref_name, 'v')
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Parse version
+        if: startsWith(github.ref_name, 'v')
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Build and push container image
+        if: startsWith(github.ref_name, 'v')
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,20 @@
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+ARG TARGETOS TARGETARCH
+
+RUN apk add -U --no-cache ca-certificates tzdata
+
+WORKDIR /build
+COPY ./ ./
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build github.com/alexbakker/alertmanager-ntfy/cmd/alertmanager-ntfy
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/share/zoneinfo/ /usr/share/zoneinfo/
+COPY --from=builder /build/alertmanager-ntfy /bin/
+
+EXPOSE 8000
+ENTRYPOINT ["/bin/alertmanager-ntfy"]
+
+LABEL org.opencontainers.image.source=https://github.com/alexbakker/alertmanager-ntfy
+LABEL org.opencontainers.image.description="Container image for alertmanager-ntfy"
+LABEL org.opencontainers.image.licenses=GPL-3.0-only


### PR DESCRIPTION
Hey there. I'm interesting in running alertmanager-ntfy on my Kubernetes cluster. I've created this PR to add a `Containerfile` which seems to build OK in my tests. I'm experienced at Kubernetes but this is the first time I've tried to build Golang so I hope the build process is OK.

I've also added a GitHub action for building the image when a GitHub Release is tagged. At the moment the image doesn't get pushed anywhere (the Docker login step is commented, and the build step has `push: no`).

Please would you consider pushing the container image to some registry, either Dockerhub or GHCR?

I'm happy to contribute a Helm chart once there's a published image :slightly_smiling_face: Also happy to explain any of the stuff I've contributed.

Thanks,
Jonathan