### PR TITLE
feat: Allow custom headers

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -29,3 +29,6 @@ ntfy:
         {{ if eq .Status "resolved" }}Resolved: {{ end }}{{ index .Annotations "summary" }}
       description: |
         {{ index .Annotations "description" }}
+      headers:
+        X-Click: |
+          {{ .GeneratorURL }}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,8 +23,9 @@ type Expression struct {
 }
 
 type Templates struct {
-	Title       *Template `yaml:"title"`
-	Description *Template `yaml:"description"`
+	Title       *Template            `yaml:"title"`
+	Description *Template            `yaml:"description"`
+	Headers     map[string]*Template `yaml:headers`
 }
 
 type Tag struct {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -189,6 +189,15 @@ func (s *Server) forwardAlert(logger *zap.Logger, alert *alertmanager.Alert) err
 			req.Header.Set("X-Priority", priority)
 		}
 	}
+	for headerName, headerTemplate := range s.cfg.Ntfy.Notification.Templates.Headers {
+		var headerBuf bytes.Buffer
+		if err := (*template.Template)(headerTemplate).Execute(&headerBuf, alert); err != nil {
+			return fmt.Errorf("render header %s template: %w", headerName, err)
+		}
+		headerValue := strings.ReplaceAll(strings.TrimSpace(headerBuf.String()), "\n", "")
+
+		req.Header.Set(headerName, headerValue)
+	}
 
 	res, err := s.http.Do(req)
 	if err != nil {


### PR DESCRIPTION
This change allows you to send custom, templated headers to ntfy.

## [Click Action](https://docs.ntfy.sh/publish/#click-action)

```yaml
ntfy:
  notification:
    templates:
      headers:
        X-Click: |
          {{ .GeneratorURL }}
```

![](https://github.com/user-attachments/assets/4bc4d146-03a9-4bfa-91cf-1596a041c4e8)

## [Action Buttons](https://docs.ntfy.sh/publish/#action-buttons)

Example: [Pre-populated silence filter](https://www.robustperception.io/pre-populated-silence-urls/)

```yaml
ntfy:
  notification:
    templates:
      headers:
        X-Actions: |
          view, View, {{ .GeneratorURL }};
          view, Silence, https://alertmanager.example.com/#/silences/new?comment=created via ntfy
```

![](https://github.com/user-attachments/assets/71f04b5e-9c43-4a32-a66f-3c53eacb1161)

## Other

Can also be used for:

- [Attachments](https://docs.ntfy.sh/publish/#attachments)
- [Icons](https://docs.ntfy.sh/publish/#icons)