### PR TITLE
feat: implement FailOnForwardError toggle for webhook forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ ntfy:
       headers:
         X-Click: |
           {{ .GeneratorURL }}
+  # Whether to forward alerts asynchronously. When enabled, a 202 status code is
+  # returned immediately. When disabled, forwarding errors result in a 5xx status
+  # code.
+  async: false
 ```
 
 There are a couple of command line options as well that can be used to override

--- a/config.example.yml
+++ b/config.example.yml
@@ -33,3 +33,7 @@ ntfy:
       headers:
         X-Click: |
           {{ .GeneratorURL }}
+  # Whether to forward alerts asynchronously. When enabled, a 202 status code is
+  # returned immediately. When disabled, forwarding errors result in a 5xx status
+  # code.
+  async: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type Ntfy struct {
 	Timeout      time.Duration `yaml:"timeout"`
 	Auth         *NtfyAuth     `yaml:"auth"`
 	Notification Notification  `yaml:"notification"`
+	Async        bool          `yaml:"async"`
 }
 
 type HTTP struct {


### PR DESCRIPTION
Closes https://github.com/alexbakker/alertmanager-ntfy/issues/14

Adds a config option `failOnForwardError` which results in http status code 502 being returned if forwarding fails for at least one alert. That signals a transient failure to AlertManager, which will cause AlertManager to retry submission.
