### PR TITLE
Enable latest and stable version series pulls for Docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,11 @@ jobs:
       - name: Parse version
         if: startsWith(github.ref_name, 'v')
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "major=${VERSION%%.*}" >> $GITHUB_OUTPUT
+          echo "major_minor=${VERSION%.*}" >> $GITHUB_OUTPUT
       - name: Build and push container image
         if: startsWith(github.ref_name, 'v')
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
@@ -77,3 +81,6 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major_minor }}
+            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+            ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
In addition to the full version tag (`1.1.0` for the most recent release), this PR changes the workflow to also add tags for the minor version (`1.1`), the major version (`1`), and the `latest` version. Thus, it’s possible to pull images by major or minor version to stay on a stable release series while receiving bug fixes and minor updates without unexpectedly jumping to a new major version. Or just use the latest version.

This also enables running alertmanager-ntfy without specifying a version tag, which is currently not possible:

```
$ docker run --rm ghcr.io/alexbakker/alertmanager-ntfy --help
Trying to pull ghcr.io/alexbakker/alertmanager-ntfy:latest...
Error: unable to copy from source docker://ghcr.io/alexbakker/alertmanager-ntfy:latest: initializing source docker://ghcr.io/alexbakker/alertmanager-ntfy:latest: reading manifest latest in ghcr.io/alexbakker/alertmanager-ntfy: manifest unknown
```